### PR TITLE
ci: use env files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Configure Go Environment
         run: |
-          echo GOPATH::${{ runner.workspace }} >> $GITHUB_ENV
+          echo GOPATH=${{ runner.workspace }} >> $GITHUB_ENV
           echo ${{ runner.workspace }}/bin >> $GITHUB_PATH
       - name: Checkout code
         uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
     steps:
       - name: Configure Go Environment
         run: |
-          echo ::set-env name=GOPATH::${{ runner.workspace }}
-          echo ::add-path::${{ runner.workspace }}/bin
+          echo GOPATH::${{ runner.workspace }} >> $GITHUB_ENV
+          echo ${{ runner.workspace }}/bin >> $GITHUB_PATH
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Bootstrap

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Configure Go Environment
         run: |
-          echo GOPATH::${{ runner.workspace }} >> $GITHUB_ENV
+          echo GOPATH=${{ runner.workspace }} >> $GITHUB_ENV
           echo ${{ runner.workspace }}/bin >> $GITHUB_PATH
       - name: Checkout code
         uses: actions/checkout@v1

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -17,8 +17,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Configure Go Environment
         run: |
-          echo ::set-env name=GOPATH::${{ runner.workspace }}
-          echo ::add-path::${{ runner.workspace }}/bin
+          echo GOPATH::${{ runner.workspace }} >> $GITHUB_ENV
+          echo ${{ runner.workspace }}/bin >> $GITHUB_PATH
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Bootstrap


### PR DESCRIPTION
Switch to env files following the deprecation of set-env and add-path commands.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/