### PR TITLE
bump goreleaser to v0.177.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5e15885530fb01d81d1f24e8a6f54ebbd0fed7eb # v2.5.0
         with:
-          version: v0.160.0
+          version: v0.177.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,7 +6,7 @@ set -exuo pipefail
 curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "${GOPATH}/bin" v1.38.0
 
 # Install goreleaser.
-curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- -b "${GOPATH}/bin" v0.160.0
+curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- -b "${GOPATH}/bin" v0.177.0
 
 # Install godownloader.
 #


### PR DESCRIPTION
CI jobs are failing in the goreleaser install step:

https://github.com/mmcloughlin/addchain/runs/3515213434?check_suite_focus=true#step:5:16

Upgrading to latest version fixes the problem.