### PR TITLE
cmd/addchain: search options to modify costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ addchain: expr: "2^255 - 19 - 2"
 addchain: hex: 7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeb
 addchain: dec: 57896044618658097711785492504343953926634992332820282019728792003956564819947
 addchain: best: opt(runs(continued_fractions(dichotomic)))
+addchain: cost: 266
 _10       = 2*1
 _11       = 1 + _10
 _1100     = _11 << 2

--- a/internal/examples/cli/output
+++ b/internal/examples/cli/output
@@ -2,6 +2,7 @@ addchain: expr: "2^255 - 19 - 2"
 addchain: hex: 7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeb
 addchain: dec: 57896044618658097711785492504343953926634992332820282019728792003956564819947
 addchain: best: opt(runs(continued_fractions(dichotomic)))
+addchain: cost: 266
 _10       = 2*1
 _11       = 1 + _10
 _1100     = _11 << 2


### PR DESCRIPTION
Doubling (squaring) is typically cheaper than addition (multiplication). This
PR adds options to the search subcommand to score addition chains based on a
weighted sum.

Closes #55
Updates #117