### PR TITLE
script: use go install for goreleaser

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,7 +6,7 @@ set -exuo pipefail
 curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "${GOPATH}/bin" v1.38.0
 
 # Install goreleaser.
-curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh -s -- -b "${GOPATH}/bin" v0.177.0
+go install github.com/goreleaser/goreleaser@v0.177.0
 
 # Install godownloader.
 #


### PR DESCRIPTION
The existing install script appears to be broken on Mac:

```
m1:addchain mbm$ ./script/bootstrap
...
+ curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh
+ sh -s -- -b /Users/mbm/Development/gopath/bin v0.177.0
goreleaser/goreleaser crit uname_arch_check 'arm64' got converted to 'all' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib
```

This install method was also recently removed from the goreleaser documentation:

https://github.com/goreleaser/goreleaser/commit/7ddcfb08464583ef0432b2170b0184f5a57ea1a8