### PR TITLE
script: use install.sh from golangci-lint repo

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,7 +3,9 @@
 set -exuo pipefail
 
 # Install golangci-lint
-curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b "${GOPATH}/bin" v1.38.0
+golangci_lint_version='v1.38.0'
+golangci_install_script="https://raw.githubusercontent.com/golangci/golangci-lint/${golangci_lint_version}/install.sh"
+curl -sfL "${golangci_install_script}" | sh -s -- -b "$GOPATH/bin" "${golangci_lint_version}"
 
 # Install goreleaser.
 go install github.com/goreleaser/goreleaser@v0.177.0


### PR DESCRIPTION
The goreleaser script has been deprecated:

https://github.com/goreleaser/godownloader/issues/207