### PR TITLE
acc/pass: handle missing allocations

### DIFF
--- a/acc/pass/alloc.go
+++ b/acc/pass/alloc.go
@@ -117,7 +117,7 @@ func (a *allocation) Allocate(i int) {
 		return
 	}
 
-	// If there's nothing available, we'll need one more temporary.
+	// If there's nothing available, we'll need another variable.
 	if len(a.available) == 0 {
 		a.available = append(a.available, a.n)
 		a.n++


### PR DESCRIPTION
The variable allocator currently raises an assertion error if it encounters a
write to an operand without an allocation.  Allocation is done like liveness
analysis: the instructions are processed in reverse and variables are
allocated as they are read, freed when they're written to. Therefore this
assertion would trigger if the operand is never read after it's written.

Therefore, this would only happen for a _redundant_ chain which computes a
value it never needs. Clearly this isn't ideal, but it does seem to happen for
some algorithms.  It seems best that the allocator doesn't crash in these
cases.

This PR updates the allocation logic to handle this case. In practice if this
happens the variable would be immediately allocated and freed.

Updates #129 #133 #136