### PR TITLE
all: upgrade to golangci-lint v1.55.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - golint
     - gomnd
     - ifshort
+    - inamedparam
     - interfacer
     - ireturn
     - lll
@@ -37,11 +38,57 @@ linters:
     - wsl
 
 linters-settings:
+  depguard:
+    rules:
+      main:
+        allow:
+          - github.com/mmcloughlin/addchain
+          - github.com/mmcloughlin/profile
+          - github.com/google/subcommands
+          - $gostd
   gci:
     sections:
-     - standard
-     - default
-     - prefix(github.com/mmcloughlin/addchain)
+      - standard
+      - default
+      - prefix(github.com/mmcloughlin/addchain)
+
+  revive:
+    enable-all-rules: true
+    confidence: 1.0
+    rules:
+      - name: add-constant
+        disabled: true
+      - name: bare-return
+        disabled: true
+      - name: confusing-naming
+        disabled: true
+      - name: cognitive-complexity
+        disabled: true
+      - name: cyclomatic
+        disabled: true
+      - name: deep-exit
+        disabled: true
+      - name: empty-block
+        disabled: true
+      - name: function-length
+        disabled: true
+      - name: import-shadowing
+        disabled: true
+      - name: line-length-limit
+        disabled: true
+      - name: max-public-structs
+        disabled: true
+      - name: unchecked-type-assertion
+        disabled: true
+      - name: unhandled-error
+        arguments:
+          - 'fmt\.(P|Fp)rint(ln|f)?'
+      - name: unused-parameter
+        disabled: true
+      - name: unused-receiver
+        disabled: true
+      - name: use-any
+        disabled: true
 
 issues:
   exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/mmcloughlin/addchain)
-
   revive:
     enable-all-rules: true
     confidence: 1.0

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,7 +3,7 @@
 set -exuo pipefail
 
 # Install golangci-lint
-golangci_lint_version='v1.51.2'
+golangci_lint_version='v1.55.2'
 golangci_install_script="https://raw.githubusercontent.com/golangci/golangci-lint/${golangci_lint_version}/install.sh"
 curl -sfL "${golangci_install_script}" | sh -s -- -b "$GOPATH/bin" "${golangci_lint_version}"
 


### PR DESCRIPTION
Upgrade `golangci-lint` to address a bug triggered since Go 1.21.5.

See: golangci/golangci-lint#3718
See: golang/go#64592
