### PR TITLE
ci: disable windows install job

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -17,7 +17,7 @@ jobs:
   install:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
Temporarily disable the installation workflow on Windows.

The workflow is currently broken due to actions/runner-images#10009 with no
clear workaround at the moment.

Updates #151
